### PR TITLE
Allow for sf object as input to `delineate_segments`

### DIFF
--- a/R/segments.R
+++ b/R/segments.R
@@ -5,7 +5,7 @@
 #'
 #' @param corridor The river corridor as a simple feature geometry
 #' @param network The spatial network to be used for the segmentation
-#' @param river_centerline The river centerline as a simple feature geometry
+#' @param river The river centerline as a simple feature geometry
 #' @param angle_threshold Only consider angles above this threshold (in degrees)
 #'   to form continuous strokes in the network. See [`rcoins::stroke()`] for
 #'   more details.
@@ -17,19 +17,21 @@
 #' corridor <- bucharest_dambovita$corridor
 #' network <- rbind(bucharest_osm$streets, bucharest_osm$railways) |>
 #'   as_network()
-#' river_centerline <- bucharest_osm$river_centerline |> sf::st_geometry()
-#' delineate_segments(corridor, network, river_centerline)
-delineate_segments <- function(corridor, network, river_centerline,
+#' river <- bucharest_osm$river_centerline |> sf::st_geometry()
+#' delineate_segments(corridor, network, river)
+delineate_segments <- function(corridor, network, river,
                                angle_threshold = 100) {
+  # Drop all attributes of river but its geometry
+  river <- sf::st_geometry(river)
 
   # Find river crossings in the network and build continuous strokes from them
-  crossings <- get_intersecting_edges(network, river_centerline, index = TRUE)
+  crossings <- get_intersecting_edges(network, river, index = TRUE)
   crossing_strokes <- rcoins::stroke(network, from_edge = crossings,
                                      angle_threshold = angle_threshold)
 
   # Clip strokes to the corridor extent and select non-intersecting strokes as
   # segment boundaries
-  segment_edges <- clip_and_filter(crossing_strokes, corridor, river_centerline)
+  segment_edges <- clip_and_filter(crossing_strokes, corridor, river)
 
   # Split the corridor into the segments using the selected boundaries
   split_by(corridor, segment_edges)
@@ -46,22 +48,22 @@ delineate_segments <- function(corridor, network, river_centerline,
 #'
 #' @param lines Candidate segment edges as a simple feature geometry
 #' @param corridor The river corridor as a simple feature geometry
-#' @param river_centerline The river centerline as a simple feature geometry
+#' @param river The river centerline as a simple feature geometry
 #'
 #' @return Candidate segment edges as a simple feature geometry
 #' @importFrom rlang .data
 #' @keywords internal
-clip_and_filter <- function(lines, corridor, river_centerline) {
+clip_and_filter <- function(lines, corridor, river) {
 
   # Split corridor along the river centerline to find edges on the two sides
-  corridor_edges <- get_corridor_edges(corridor, river_centerline)
+  corridor_edges <- get_corridor_edges(corridor, river)
 
   # Clip the lines, keeping the only fragments that intersect the river
   lines_clipped <- sf::st_intersection(lines, corridor) |>
     sf::st_as_sf() |>
     dplyr::filter(sf::st_is(.data$x, c("MULTILINESTRING", "LINESTRING"))) |>
     sfheaders::sf_cast("LINESTRING") |>
-    sf::st_filter(river_centerline, .predicate = sf::st_intersects) |>
+    sf::st_filter(river, .predicate = sf::st_intersects) |>
     sf::st_geometry()
 
   # Select the fragments intersecting both sides of the corridor
@@ -72,7 +74,7 @@ clip_and_filter <- function(lines, corridor, river_centerline) {
   lines_valid <- lines_clipped[intersects_side_1 & intersects_side_2]
 
   # Cluster valid segment edges and select the shortest line per cluster
-  lines_shortest <- filter_clusters(lines_valid, river_centerline)
+  lines_shortest <- filter_clusters(lines_valid, river)
 
   # Drop intersecting lines, starting from the longest line with most
   # intersections with other lines
@@ -82,12 +84,12 @@ clip_and_filter <- function(lines, corridor, river_centerline) {
 #' Split corridor along the river to find edges on the two banks
 #'
 #' @param corridor The river corridor as a simple feature geometry
-#' @param river_centerline The river centerline as a simple feature geometry
+#' @param river The river centerline as a simple feature geometry
 #'
 #' @return Corridor edges as a simple feature geometry
 #' @keywords internal
-get_corridor_edges <- function(corridor, river_centerline) {
-  corridor_edges <- split_by(corridor, river_centerline, boundary = TRUE)
+get_corridor_edges <- function(corridor, river) {
+  corridor_edges <- split_by(corridor, river, boundary = TRUE)
   # For complex river geometries, splitting the corridor might actually return
   # multiple linestrings - select here the two longest segments
   if (length(corridor_edges) < 2) stop("Cannot identify corridor edges")

--- a/man/clip_and_filter.Rd
+++ b/man/clip_and_filter.Rd
@@ -4,14 +4,14 @@
 \alias{clip_and_filter}
 \title{Clip lines to the extent of the corridor, and select valid segment edges}
 \usage{
-clip_and_filter(lines, corridor, river_centerline)
+clip_and_filter(lines, corridor, river)
 }
 \arguments{
 \item{lines}{Candidate segment edges as a simple feature geometry}
 
 \item{corridor}{The river corridor as a simple feature geometry}
 
-\item{river_centerline}{The river centerline as a simple feature geometry}
+\item{river}{The river centerline as a simple feature geometry}
 }
 \value{
 Candidate segment edges as a simple feature geometry

--- a/man/delineate_segments.Rd
+++ b/man/delineate_segments.Rd
@@ -4,14 +4,14 @@
 \alias{delineate_segments}
 \title{Split a river corridor into segments}
 \usage{
-delineate_segments(corridor, network, river_centerline, angle_threshold = 100)
+delineate_segments(corridor, network, river, angle_threshold = 100)
 }
 \arguments{
 \item{corridor}{The river corridor as a simple feature geometry}
 
 \item{network}{The spatial network to be used for the segmentation}
 
-\item{river_centerline}{The river centerline as a simple feature geometry}
+\item{river}{The river centerline as a simple feature geometry}
 
 \item{angle_threshold}{Only consider angles above this threshold (in degrees)
 to form continuous strokes in the network. See \code{\link[rcoins:stroke]{rcoins::stroke()}} for
@@ -29,6 +29,6 @@ bucharest_osm <- get_osm_example_data()
 corridor <- bucharest_dambovita$corridor
 network <- rbind(bucharest_osm$streets, bucharest_osm$railways) |>
   as_network()
-river_centerline <- bucharest_osm$river_centerline |> sf::st_geometry()
-delineate_segments(corridor, network, river_centerline)
+river <- bucharest_osm$river_centerline |> sf::st_geometry()
+delineate_segments(corridor, network, river)
 }

--- a/man/get_corridor_edges.Rd
+++ b/man/get_corridor_edges.Rd
@@ -4,12 +4,12 @@
 \alias{get_corridor_edges}
 \title{Split corridor along the river to find edges on the two banks}
 \usage{
-get_corridor_edges(corridor, river_centerline)
+get_corridor_edges(corridor, river)
 }
 \arguments{
 \item{corridor}{The river corridor as a simple feature geometry}
 
-\item{river_centerline}{The river centerline as a simple feature geometry}
+\item{river}{The river centerline as a simple feature geometry}
 }
 \value{
 Corridor edges as a simple feature geometry


### PR DESCRIPTION
`delineate_segments` currently fail if a `sf` object is passed as input - this PR makes the usage slightly more flexible. 

Also, rename `river_centerline` -> `river` for simplicity and consistency with `delineate_corridor`.