### PR TITLE
Small fixes in OSM related functions

### DIFF
--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -285,14 +285,14 @@ get_osm_streets <- function(aoi, crs = NULL, highway_values = NULL,
                             force_download = FALSE) {
   if (is.null(highway_values)) {
     highway_values <- c("motorway", "trunk", "primary", "secondary", "tertiary")
+    link_values <- vapply(X = highway_values,
+                          FUN = \(x) sprintf("%s_link", x),
+                          FUN.VALUE = character(1),
+                          USE.NAMES = FALSE)
+    highway_values <- c(highway_values, link_values)
   }
 
-  link_values <- vapply(X = highway_values,
-                        FUN = \(x) sprintf("%s_link", x),
-                        FUN.VALUE = character(1),
-                        USE.NAMES = FALSE)
-
-  streets <- osmdata_as_sf("highway", c(highway_values, link_values), aoi,
+  streets <- osmdata_as_sf("highway", highway_values, aoi,
                            force_download = force_download)
 
   # Cast polygons (closed streets) into lines
@@ -321,6 +321,8 @@ get_osm_streets <- function(aoi, crs = NULL, highway_values = NULL,
 #'
 #' @param aoi Area of interest as sf object or bbox
 #' @param crs Coordinate reference system as EPSG code
+#' @param railway_values A character or character vector with the highway values
+#'   to retrieve.
 #' @param force_download Download data even if cached data is available
 #'
 #' @return An sf object with the railways
@@ -331,8 +333,9 @@ get_osm_streets <- function(aoi, crs = NULL, highway_values = NULL,
 #' bb <- get_osm_bb("Bucharest")
 #' crs <- get_utm_zone(bb)
 #' get_osm_railways(bb, crs)
-get_osm_railways <- function(aoi, crs = NULL, force_download = FALSE) {
-  railways <- osmdata_as_sf("railway", "rail", aoi,
+get_osm_railways <- function(aoi, crs = NULL, railway_values = "rail",
+                             force_download = FALSE) {
+  railways <- osmdata_as_sf("railway", railway_values, aoi,
                             force_download = force_download)
   # If no railways are found, return an empty sf object
   if (is.null(railways$osm_lines)) {

--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -327,7 +327,7 @@ get_osm_streets <- function(aoi, crs = NULL, highway_values = NULL,
 #'
 #' @param aoi Area of interest as sf object or bbox
 #' @param crs Coordinate reference system as EPSG code
-#' @param railway_values A character or character vector with the highway values
+#' @param railway_values A character or character vector with the railway values
 #'   to retrieve.
 #' @param force_download Download data even if cached data is available
 #'

--- a/man/get_osm_railways.Rd
+++ b/man/get_osm_railways.Rd
@@ -16,7 +16,7 @@ get_osm_railways(
 
 \item{crs}{Coordinate reference system as EPSG code}
 
-\item{railway_values}{A character or character vector with the highway values
+\item{railway_values}{A character or character vector with the railway values
 to retrieve.}
 
 \item{force_download}{Download data even if cached data is available}

--- a/man/get_osm_railways.Rd
+++ b/man/get_osm_railways.Rd
@@ -4,12 +4,20 @@
 \alias{get_osm_railways}
 \title{Get OpenStreetMap railways}
 \usage{
-get_osm_railways(aoi, crs = NULL, force_download = FALSE)
+get_osm_railways(
+  aoi,
+  crs = NULL,
+  railway_values = "rail",
+  force_download = FALSE
+)
 }
 \arguments{
 \item{aoi}{Area of interest as sf object or bbox}
 
 \item{crs}{Coordinate reference system as EPSG code}
+
+\item{railway_values}{A character or character vector with the highway values
+to retrieve.}
 
 \item{force_download}{Download data even if cached data is available}
 }


### PR DESCRIPTION
Small fixes in the osmdata module:

* Allow to specify arbitrary highway and railway values (currently there is a problem with the links in the street function)
* For the river centerline and surface, the osm_multi* geometries are in few cases not defined - rcrisp used to fail then.  