### PR TITLE
Fix test paths for Windows

### DIFF
--- a/tests/testthat/test-osmdata.R
+++ b/tests/testthat/test-osmdata.R
@@ -87,7 +87,7 @@ test_that("Queried datasets can be retrieved from the cache on new calls", {
   # calling get_osm_railways again should read data from the cached file,
   # raising a warning that includes the path to the cached file as well
   expect_warning(get_osm_railways(bb, force_download = FALSE),
-                 cached_filepath)
+                 cached_filepath, fixed = TRUE)
 })
 
 test_that("City boundary is retreived for alternative names", {

--- a/tests/testthat/test-valley.R
+++ b/tests/testthat/test-valley.R
@@ -54,7 +54,7 @@ test_that("Download DEM data can be retrieved from the cache on new calls", {
   # calling load_dem again should read data from the cached file, raising a
   # warning that includes the path to the cached file as well
   expect_warning(load_dem(bb, asset_urls, force_download = FALSE),
-                 cached_filepath)
+                 cached_filepath, fixed = TRUE)
 })
 
 test_that("valley polygon is correctly constructed", {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adding `fixed = TRUE` prevents `expect_warning()` from looking for a regexp. This fixes the issue.

## Related Issues

- Related Issue #210 
- Closes #210 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 75% and above._

- [ ] Yes
- [x] No, and this is why: fixed two existing tests
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [ ] Yes
