### PR TITLE
Fix clean network example performance cf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rcrisp
 Title: Automate the Delineation of Urban River Spaces
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Claudiu", "Forgaci", , "c.forgaci@tudelft.nl", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-3218-5102")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
-# Version 0.1.0
+# Version 0.1.1 - 2025-06-24
+
+## Fixed
+
+- Examples that take too long to run are only run in interactive mode
+
+# Version 0.1.0 - 2025-06-23
 
 ## Added
 

--- a/R/network.R
+++ b/R/network.R
@@ -175,7 +175,7 @@ calc_rolling_sum <- function(x, n = 2) {
 #'
 #' @return A cleaned network object
 #' @export
-#' @examples
+#' @examplesIf interactive()
 #' bucharest_osm <- get_osm_example_data()
 #' edges <- dplyr::bind_rows(bucharest_osm$streets,
 #'                           bucharest_osm$railways)

--- a/codemeta.json
+++ b/codemeta.json
@@ -2,12 +2,12 @@
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
   "@type": "SoftwareSourceCode",
   "identifier": "rcrisp",
-  "description": "Provides tools to automate the morphological delineation of riverside urban areas, based on a method introduced in Forgaci (2018) <doi:10.7480/abe.2018.31>. Delineation entails the identification of corridor boundaries, segmentation of the corridor, and delineation of the river space. The resulting delineation can be used to charactarise spatial phenomena that can be related to the river as a central element.",
+  "description": "Provides tools to automate the morphological delineation of riverside urban areas, based on a method introduced in Forgaci (2018) <doi:10.7480/abe.2018.31>. Delineation entails the identification of corridor boundaries, segmentation of the corridor, and delineation of the river space. The resulting delineation can be used to characterise spatial phenomena that can be related to the river as a central element.",
   "name": "rcrisp: Automate the Delineation of Urban River Spaces",
   "codeRepository": "https://github.com/CityRiverSpaces/rcrisp",
-  "issueTracker": "https://github.com/CityRiverSpaces/crisp/issues",
+  "issueTracker": "https://github.com/CityRiverSpaces/rcrisp/issues",
   "license": "Apache License 2",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -151,7 +151,7 @@
       "@type": "SoftwareApplication",
       "identifier": "R",
       "name": "R",
-      "version": ">= 3.5"
+      "version": ">= 4.1.0"
     },
     "2": {
       "@type": "SoftwareApplication",
@@ -335,7 +335,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "1609.573KB",
+  "fileSize": "1249.308KB",
   "relatedLink": "https://cityriverspaces.github.io/rcrisp/",
   "releaseNotes": "https://github.com/CityRiverSpaces/rcrisp/blob/master/NEWS.md",
   "readme": "https://github.com/CityRiverSpaces/rcrisp/blob/main/README.md",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -3,3 +3,10 @@
 0 errors | 0 warnings | 1 note
 
 * This is a new release.
+
+## Resubmission
+
+This is a resubmission. In this version:
+
+* The example of `clean_network()` flagged as taking too long
+is run only in interactive mode.

--- a/man/clean_network.Rd
+++ b/man/clean_network.Rd
@@ -22,9 +22,11 @@ Subdivide edges by \href{https://luukvdmeer.github.io/sfnetworks/articles/sfn02_
 and discard all but the main connected component.
 }
 \examples{
+\dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 bucharest_osm <- get_osm_example_data()
 edges <- dplyr::bind_rows(bucharest_osm$streets,
                           bucharest_osm$railways)
 network <- sfnetworks::as_sfnetwork(edges, directed = FALSE)
 clean_network(network)
+\dontshow{\}) # examplesIf}
 }

--- a/man/delineate_valley.Rd
+++ b/man/delineate_valley.Rd
@@ -24,7 +24,9 @@ The resulting area is then "polygonized" to obtain the valley boundary as a
 simple feature geometry.
 }
 \examples{
+\dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 bucharest_osm <- get_osm_example_data()
 bucharest_dem <- get_dem_example_data()
 delineate_valley(bucharest_dem, bucharest_osm$river_centerline)
+\dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
The CRAN submission flagged the example in `clean_network()` as taking too long in “Examples with CPU (user + system) or elapsed time > 5s” or "> 10s". See logs below. With this PR, the example is only run in intercative mode. I also updated the version to 0.1.1.

```
Flavor: r-devel-windows-x86_64
Check: CRAN incoming feasibility, Result: NA
  Maintainer: 'Claudiu Forgaci <EMAIL_REMOVED>'
  
  New submission
  
  Possibly misspelled words in DESCRIPTION:
    Forgaci (16:60)

Flavor: r-devel-windows-x86_64
Check: examples, Result: NA
  Examples with CPU (user + system) or elapsed time > 10s
                 user system elapsed
  clean_network 13.84   1.31   15.42

Flavor: r-devel-windows-x86_64
Check: Overall checktime, Result: NOTE
  Overall checktime 13 min > 10 min

Flavor: r-devel-linux-x86_64-debian-gcc
Check: CRAN incoming feasibility, Result: NOTE
  Maintainer: 'Claudiu Forgaci <EMAIL_REMOVED>'
  
  New submission
  
  Possibly misspelled words in DESCRIPTION:
    Forgaci (16:60)

Flavor: r-devel-linux-x86_64-debian-gcc
Check: examples, Result: NOTE
  Examples with CPU (user + system) or elapsed time > 5s
                 user system elapsed
  clean_network 6.451  0.264       7
```

## Related Issues

- Related Issue #
- Closes #

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 75% and above._

- [ ] Yes
- [x] No, and this is why: no need for tests
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [x] Yes
