### PR TITLE
Fix namespace load NOTE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rcrisp
 Title: Automate the Delineation of Urban River Spaces
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(
     person("Claudiu", "Forgaci", , "c.forgaci@tudelft.nl", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-3218-5102")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+# Version 0.1.4
+
+## Fixed
+
+- `check_cache()` is only run when the package is attached, not when it is loaded to avoid namespace issues.
+
 # Version 0.1.3 - 2025-06-27
 
 ## Fixed

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [Unreleased]
-
 # Version 0.1.4
 
 ## Fixed

--- a/R/cache.R
+++ b/R/cache.R
@@ -179,6 +179,7 @@ check_cache <- function() {
   } else {
     is_too_old <- (Sys.time() - date_oldest_file) > "30 days"
   }
+  msg <- NULL
   if (is_too_big || is_too_old) {
     msg <- sprintf(paste0(
       "Cache dir: %s - size: %.0f MB - oldest file from: %s.\n",

--- a/R/cache.R
+++ b/R/cache.R
@@ -180,11 +180,12 @@ check_cache <- function() {
     is_too_old <- (Sys.time() - date_oldest_file) > "30 days"
   }
   if (is_too_big || is_too_old) {
-    warning(sprintf(paste0(
+    msg <- sprintf(paste0(
       "Cache dir: %s - size: %.0f MB - oldest file from: %s.\n",
       "Clean up files older than 30 days with: `rcrisp::clear_cache('%s')` ",
       "(or remove all cached files with: `rcrisp::clear_cache()`."
-    ), cache_dir, cache_size, as.Date(date_oldest_file), Sys.Date() - 30
-    ))
+      ), cache_dir, cache_size, as.Date(date_oldest_file), Sys.Date() - 30
+    )
   }
+  msg
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,6 @@
-.onLoad <- function(libname, pkgname) {
-  check_cache()
+.onAttach <- function(libname, pkgname) {
+  try({
+    msg <- check_cache()
+    if (!is.null(msg)) packageStartupMessage(msg)
+  }, silent = TRUE)
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,13 +7,19 @@
   "codeRepository": "https://github.com/CityRiverSpaces/rcrisp",
   "issueTracker": "https://github.com/CityRiverSpaces/rcrisp/issues",
   "license": "Apache License 2",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
     "url": "https://r-project.org"
   },
   "runtimePlatform": "R version 4.5.0 (2025-04-11)",
+  "provider": {
+    "@id": "https://cran.r-project.org",
+    "@type": "Organization",
+    "name": "Comprehensive R Archive Network (CRAN)",
+    "url": "https://cran.r-project.org"
+  },
   "author": [
     {
       "@type": "Person",
@@ -335,7 +341,7 @@
     },
     "SystemRequirements": null
   },
-  "fileSize": "1256.962KB",
+  "fileSize": "6590.113KB",
   "relatedLink": "https://cityriverspaces.github.io/rcrisp/",
   "releaseNotes": "https://github.com/CityRiverSpaces/rcrisp/blob/master/NEWS.md",
   "readme": "https://github.com/CityRiverSpaces/rcrisp/blob/main/README.md",

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,17 +2,13 @@
 
 0 errors | 0 warnings | 1 note
 
-* This is a new release.
+Days since last update: 1
 
 ## Resubmission
 
-This is a resubmission. In this version:
+This is a resubmission in response to a problem pointed out on CRAN.
+In this version:
 
-* The default cache directory has been moved to the path given by
-  `tools::R_user_dir()`. Checks for the cache directory size and
-  outdated files are now included on package load.
-* Tests have been partly rewritten, so that they use less resources and they
-  complete in a reasonable amount of time.
-* Tests retrieving DEM data from AWS have been either removed or mocked
-  to avoid issues with the AWS API.
-* Warnings in delineation tests are safely suppressed
+* `check_cache()` is moved from `.onLoad()` to `.onAttach()` to comply with
+  CRAN policy on namespace loading.
+* The NOTE on namespace load is resolved.

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -146,7 +146,7 @@ test_that("Cache checks raise warnings when old cached files are found", {
   )
   with_mocked_bindings(file.info = function(...) mocked_file_info_response,
                        .package = "base",
-                       expect_warning(check_cache()))
+                       expect_type(check_cache(), "character"))
 })
 
 test_that("Cache checks raise warnings when large cached files are found", {
@@ -156,5 +156,6 @@ test_that("Cache checks raise warnings when large cached files are found", {
   )
   with_mocked_bindings(file.info = function(...) mocked_file_info_response,
                        .package = "base",
-                       expect_warning(check_cache()))
+                       expect_type(check_cache(), "character"))
 })
+


### PR DESCRIPTION
This resolves the NOTE on namespace load. I repalced `.onLoad()` with `.onAttach()` so that `check_cache()` is only triggered when the user executes `library(rcrisp)`. Also, the warning used in `check_cache()` is now replaced by a startup message.