### PR TITLE
Update compliance with standard G2.7

### DIFF
--- a/R/corridor.R
+++ b/R/corridor.R
@@ -39,7 +39,11 @@
 #' corridor_init <- delineate_valley(bucharest_dem, river)
 #' delineate_corridor(network, river, corridor_init = corridor_init,
 #'                    max_width = 4000, max_iterations = 5, capping = "direct")
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `network` object provided as input must be of class
+#'   `sfnetwork`. `sfnetwork` objects are `sf`-compatible and are commonly used
+#'   for spatial network analysis. The `river` parameter accepts inputs of type
+#'   `sf` and `sfc`. In the current implementation, any other form of tabular
+#'   input is rejected.
 delineate_corridor <- function(
   network, river, corridor_init = 1000, max_width = 3000, max_iterations = 10,
   capping_method = "shortest-path"

--- a/R/corridor.R
+++ b/R/corridor.R
@@ -39,6 +39,7 @@
 #' corridor_init <- delineate_valley(bucharest_dem, river)
 #' delineate_corridor(network, river, corridor_init = corridor_init,
 #'                    max_width = 4000, max_iterations = 5, capping = "direct")
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 delineate_corridor <- function(
   network, river, corridor_init = 1000, max_width = 3000, max_iterations = 10,
   capping_method = "shortest-path"

--- a/R/network.R
+++ b/R/network.R
@@ -20,6 +20,7 @@
 #'
 #' # Only build the spatial network
 #' as_network(edges, flatten = FALSE, clean = FALSE)
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 as_network <- function(edges, flatten = TRUE, clean = TRUE) {
   # Check input
   checkmate::assert_true(inherits(edges, c("sf", "sfc")))
@@ -54,6 +55,7 @@ as_network <- function(edges, flatten = TRUE, clean = TRUE) {
 #'                           bucharest_osm$railways)
 #' network <- sfnetworks::as_sfnetwork(edges, directed = FALSE)
 #' flatten_network(network)
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 flatten_network <- function(network) {
   nodes <- sf::st_as_sf(network, "nodes")
   edges <- sf::st_as_sf(network, "edges")
@@ -205,6 +207,7 @@ calc_rolling_sum <- function(x, n = 2) {
 #'                           bucharest_osm$railways)
 #' network <- sfnetworks::as_sfnetwork(edges, directed = FALSE)
 #' clean_network(network)
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 clean_network <- function(network, simplify = TRUE) {
   # Check input
   checkmate::assert_class(network, "sfnetwork")
@@ -279,6 +282,7 @@ simplify_network <- function(network) {
 #'
 #' @srrstats {G2.4, G2.4b} Explicit conversion of logical vector to numeric with
 #' `as.numeric()` used for calculating penalty weights.
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 add_weights <- function(network, target = NULL, exclude_area = NULL,
                         penalty = 1000., weight_name = "weight") {
   edges <- sf::st_geometry(sf::st_as_sf(network, "edges"))

--- a/R/network.R
+++ b/R/network.R
@@ -1,6 +1,6 @@
 #' Create a network from a collection of line strings.
 #'
-#' @param edges An `sfc_LINESTRING` object with the network edges
+#' @param edges An `sf` or `sfc_LINESTRING` object with the network edges
 #' @param flatten Whether all intersections between edges should be
 #'   converted to nodes
 #' @param clean Whether general cleaning tasks should be run on the generated
@@ -20,7 +20,9 @@
 #'
 #' # Only build the spatial network
 #' as_network(edges, flatten = FALSE, clean = FALSE)
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `edges` parameter only accepts tabular input of class
+#'   `sf`. `sfnetwork` objects are `sf`-compatible and are commonly used
+#'   for spatial network analysis.
 as_network <- function(edges, flatten = TRUE, clean = TRUE) {
   # Check input
   checkmate::assert_true(inherits(edges, c("sf", "sfc")))
@@ -55,7 +57,9 @@ as_network <- function(edges, flatten = TRUE, clean = TRUE) {
 #'                           bucharest_osm$railways)
 #' network <- sfnetworks::as_sfnetwork(edges, directed = FALSE)
 #' flatten_network(network)
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `network` object provided as input must be of class
+#'   `sfnetwork`. `sfnetwork` objects are `sf`-compatible and are commonly used
+#'   for spatial network analysis.
 flatten_network <- function(network) {
   nodes <- sf::st_as_sf(network, "nodes")
   edges <- sf::st_as_sf(network, "edges")
@@ -207,7 +211,9 @@ calc_rolling_sum <- function(x, n = 2) {
 #'                           bucharest_osm$railways)
 #' network <- sfnetworks::as_sfnetwork(edges, directed = FALSE)
 #' clean_network(network)
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `network` object provided as input must be of class
+#'   `sfnetwork`. `sfnetwork` objects are `sf`-compatible and are commonly used
+#'   for spatial network analysis.
 clean_network <- function(network, simplify = TRUE) {
   # Check input
   checkmate::assert_class(network, "sfnetwork")
@@ -282,7 +288,9 @@ simplify_network <- function(network) {
 #'
 #' @srrstats {G2.4, G2.4b} Explicit conversion of logical vector to numeric with
 #' `as.numeric()` used for calculating penalty weights.
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `network` object provided as input must be of class
+#'   `sfnetwork`. `sfnetwork` objects are `sf`-compatible and are commonly used
+#'   for spatial network analysis.
 add_weights <- function(network, target = NULL, exclude_area = NULL,
                         penalty = 1000., weight_name = "weight") {
   edges <- sf::st_geometry(sf::st_as_sf(network, "edges"))

--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -17,7 +17,8 @@
 #' osmdata_as_sf("highway", "motorway", bb, force_download = TRUE)
 #' @srrstats {G4.0} OSM data is saved with a file name concatenated from the
 #'   OSM "key", "value" and "bbox" coordinates.
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `aoi` parameter accepts domain-specific tabular input
+#'   of type `sf`.
 osmdata_as_sf <- function(key, value, aoi, force_download = FALSE) {
   # Check input
   checkmate::assert_character(key, len = 1)
@@ -466,7 +467,8 @@ get_osm_buildings <- function(aoi, crs = NULL, force_download = FALSE) {
 #' bb <- get_osm_bb("Bucharest")
 #' river <- get_osm_river(bb, "Dâmbovița")
 #' get_river_aoi(river, bb, buffer_distance = 100)
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `river` parameter accepts domain-specific tabular input
+#'   of type `sf`.
 get_river_aoi <- function(river, city_bbox, buffer_distance) {
   # Check input
   checkmate::assert_numeric(buffer_distance, len = 1)
@@ -478,7 +480,6 @@ get_river_aoi <- function(river, city_bbox, buffer_distance) {
 
   river_buffer(river, buffer_distance, bbox = city_bbox)
 }
-
 
 #' Match OpenStreetMap data by name
 #'

--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -17,6 +17,7 @@
 #' osmdata_as_sf("highway", "motorway", bb, force_download = TRUE)
 #' @srrstats {G4.0} OSM data is saved with a file name concatenated from the
 #'   OSM "key", "value" and "bbox" coordinates.
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 osmdata_as_sf <- function(key, value, aoi, force_download = FALSE) {
   # Check input
   checkmate::assert_character(key, len = 1)
@@ -465,6 +466,7 @@ get_osm_buildings <- function(aoi, crs = NULL, force_download = FALSE) {
 #' bb <- get_osm_bb("Bucharest")
 #' river <- get_osm_river(bb, "Dâmbovița")
 #' get_river_aoi(river, bb, buffer_distance = 100)
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 get_river_aoi <- function(river, city_bbox, buffer_distance) {
   # Check input
   checkmate::assert_numeric(buffer_distance, len = 1)

--- a/R/riverspace.R
+++ b/R/riverspace.R
@@ -14,7 +14,8 @@
 #'   bucharest_osm <- get_osm_example_data()
 #'   delineate_riverspace(bucharest_osm$river_surface, bucharest_osm$buildings)
 #' }
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `river` and `occluders` parameters accept
+#'   domain-specific tabular input of type `sf`.
 delineate_riverspace <- function(river, occluders = NULL, density = 1 / 50,
                                  ray_num = 40, ray_length = 100) {
   viewpoints <- visor::get_viewpoints(river, density = density)

--- a/R/riverspace.R
+++ b/R/riverspace.R
@@ -14,6 +14,7 @@
 #'   bucharest_osm <- get_osm_example_data()
 #'   delineate_riverspace(bucharest_osm$river_surface, bucharest_osm$buildings)
 #' }
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 delineate_riverspace <- function(river, occluders = NULL, density = 1 / 50,
                                  ray_num = 40, ray_length = 100) {
   viewpoints <- visor::get_viewpoints(river, density = density)

--- a/R/segments.R
+++ b/R/segments.R
@@ -23,7 +23,10 @@
 #'   as_network()
 #' river <- bucharest_osm$river_centerline |> sf::st_geometry()
 #' delineate_segments(corridor, network, river)
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `network` object provided as input must be of class
+#'   `sfnetwork`. `sfnetwork` objects are `sf`-compatible and are commonly
+#'   used for spatial network analysis. The `river` parameter accepts
+#'   domain-specific tabular input of type `sf`.
 delineate_segments <- function(corridor, network, river,
                                angle_threshold = 100) {
   # Check input

--- a/R/segments.R
+++ b/R/segments.R
@@ -23,6 +23,7 @@
 #'   as_network()
 #' river <- bucharest_osm$river_centerline |> sf::st_geometry()
 #' delineate_segments(corridor, network, river)
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 delineate_segments <- function(corridor, network, river,
                                angle_threshold = 100) {
   # Check input

--- a/R/srr-stats-standards.R
+++ b/R/srr-stats-standards.R
@@ -23,7 +23,6 @@
 #' @srrstatsTODO {G2.4b} *explicit conversion to continuous via `as.numeric()`*
 #' @srrstatsTODO {G2.4c} *explicit conversion to character via `as.character()` (and not `paste` or `paste0`)*
 #' @srrstatsTODO {G2.6} *Software which accepts one-dimensional input should ensure values are appropriately pre-processed regardless of class structures.*
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 #' @srrstatsTODO {G2.8} *Software should provide appropriate conversion or dispatch routines as part of initial pre-processing to ensure that all other sub-functions of a package receive inputs of a single defined class or type.*
 #' @srrstatsTODO {G2.9} *Software should issue diagnostic messages for type conversion in which information is lost (such as conversion of variables from factor to character; standardisation of variable names; or removal of meta-data such as those associated with [`sf`-format](https://r-spatial.github.io/sf/) data) or added (such as insertion of variable or column names where none were provided).*
 #' @srrstatsTODO {G2.10} *Software should ensure that extraction or filtering of single columns from tabular inputs should not presume any particular default behaviour, and should ensure all column-extraction operations behave consistently regardless of the class of tabular data used as input.*

--- a/R/utils.R
+++ b/R/utils.R
@@ -49,6 +49,7 @@ get_utm_zone <- function(x) {
 #' bb <- as_bbox(bounding_coords)
 #' class(bb)
 #' st_crs(bb)
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 as_bbox <- function(x) {
   # Check input
   checkmate::assert_true(
@@ -146,6 +147,7 @@ river_buffer <- function(river, buffer_distance, bbox = NULL, side = NULL) {
 #' # Reproject a raster to EPSG:4326
 #' r <- terra::rast(matrix(1:12, nrow = 3, ncol = 4), crs = "EPSG:32633")
 #' reproject(r, 4326)
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 reproject <- function(x, crs, ...) {
   if (inherits(x, "SpatRaster")) {
     if (inherits(crs, c("integer", "numeric"))) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -49,7 +49,8 @@ get_utm_zone <- function(x) {
 #' bb <- as_bbox(bounding_coords)
 #' class(bb)
 #' st_crs(bb)
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `x` parameter accepts `matrix` or domain-specific
+#'   tabular input of type `sf`.
 as_bbox <- function(x) {
   # Check input
   checkmate::assert_true(
@@ -147,7 +148,8 @@ river_buffer <- function(river, buffer_distance, bbox = NULL, side = NULL) {
 #' # Reproject a raster to EPSG:4326
 #' r <- terra::rast(matrix(1:12, nrow = 3, ncol = 4), crs = "EPSG:32633")
 #' reproject(r, 4326)
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `x` parameter also accepts domain-specific tabular
+#'   input of type `sf`.
 reproject <- function(x, crs, ...) {
   if (inherits(x, "SpatRaster")) {
     if (inherits(crs, c("integer", "numeric"))) {

--- a/R/valley.R
+++ b/R/valley.R
@@ -51,7 +51,7 @@ default_stac_dem <- list(
 #'
 #' # Specify CRS
 #' get_dem(bb, crs = crs)
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `bb` parameter accepts tabular input of class `matrix`.
 get_dem <- function(bb, dem_source = "STAC", stac_endpoint = NULL,
                     stac_collection = NULL, crs = NULL,
                     force_download = FALSE) {
@@ -93,7 +93,8 @@ get_dem <- function(bb, dem_source = "STAC", stac_endpoint = NULL,
 #' bucharest_osm <- get_osm_example_data()
 #' bucharest_dem <- get_dem_example_data()
 #' delineate_valley(bucharest_dem, bucharest_osm$river_centerline)
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `river` parameter accepts domain-specific tabular input
+#'   of type `sf`.
 delineate_valley <- function(dem, river) {
   # Check input
   checkmate::assert_class(dem, "SpatRaster")
@@ -135,7 +136,7 @@ delineate_valley <- function(dem, river) {
 #' get_stac_asset_urls(bb,
 #'                     endpoint = "some endpoint",
 #'                     collection = "some collection")
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `bb` parameter accepts tabular input of class `matrix`.
 get_stac_asset_urls <- function(bb, endpoint = NULL, collection = NULL) {
   # Check input
   bbox <- as_bbox(bb)
@@ -180,7 +181,7 @@ get_stac_asset_urls <- function(bb, endpoint = NULL, collection = NULL) {
 #' load_dem(bb, tile_urls, force_download = TRUE)
 #' @srrstats {G4.0} DEM data is written to cache with a file name concatenated
 #'   from tile names and boundig box coordinates.
-#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
+#' @srrstats {G2.7} The `bb` parameter accepts tabular input of class `matrix`.
 load_dem <- function(bb, tile_urls, force_download = FALSE) {
   # Check input
   bbox <- as_bbox(bb)

--- a/R/valley.R
+++ b/R/valley.R
@@ -51,6 +51,7 @@ default_stac_dem <- list(
 #'
 #' # Specify CRS
 #' get_dem(bb, crs = crs)
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 get_dem <- function(bb, dem_source = "STAC", stac_endpoint = NULL,
                     stac_collection = NULL, crs = NULL,
                     force_download = FALSE) {
@@ -92,6 +93,7 @@ get_dem <- function(bb, dem_source = "STAC", stac_endpoint = NULL,
 #' bucharest_osm <- get_osm_example_data()
 #' bucharest_dem <- get_dem_example_data()
 #' delineate_valley(bucharest_dem, bucharest_osm$river_centerline)
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 delineate_valley <- function(dem, river) {
   # Check input
   checkmate::assert_class(dem, "SpatRaster")
@@ -133,6 +135,7 @@ delineate_valley <- function(dem, river) {
 #' get_stac_asset_urls(bb,
 #'                     endpoint = "some endpoint",
 #'                     collection = "some collection")
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 get_stac_asset_urls <- function(bb, endpoint = NULL, collection = NULL) {
   # Check input
   bbox <- as_bbox(bb)
@@ -177,6 +180,7 @@ get_stac_asset_urls <- function(bb, endpoint = NULL, collection = NULL) {
 #' load_dem(bb, tile_urls, force_download = TRUE)
 #' @srrstats {G4.0} DEM data is written to cache with a file name concatenated
 #'   from tile names and boundig box coordinates.
+#' @srrstatsTODO {G2.7} *Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.*
 load_dem <- function(bb, tile_urls, force_download = FALSE) {
   # Check input
   bbox <- as_bbox(bb)


### PR DESCRIPTION
Citing from https://stats-devguide.ropensci.org/standards.html#tabular-input:

> - matrix form when referring to specifically two-dimensional data of one uniform type
> - array form as a more general expression, or when referring to data that are not necessarily or strictly two-dimensional
> - data.frame
> Extensions such as
> - [tibble](https://tibble.tidyverse.org/)
> - [data.table](https://rdatatable.gitlab.io/data.table)
domain-specific classes such as [tsibble](https://tsibble.tidyverts.org/) for time series, or [sf](https://r-spatial.github.io/sf/) for spatial data.

> G2.7 Software should accept as input as many of the above standard tabular forms as possible, including extension to domain-specific forms.