### PR TITLE
Prioritise exact OSM name matches

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [Unreleased]
+
+## Fixed
+
+- Exact matches in `match_osm_name()` are returned before partial matches.
+
 # rcrisp 0.2.0 - 2025-08-21
 
 ## Added

--- a/R/osmdata.R
+++ b/R/osmdata.R
@@ -592,5 +592,9 @@ match_osm_name <- function(osm_data, match) {
   includes_match <- \(x) grepl(match, x, ignore.case = TRUE)
   # Apply function above to all columns whose name starts with "name", thus
   # checking for matches in all listed languages
-  dplyr::filter(osm_data, dplyr::if_any(dplyr::matches("name"), includes_match))
+  osm_data |>
+    dplyr::filter(dplyr::if_any(dplyr::matches("name"), includes_match)) |>
+    # Make sure that exact match is in the first row(s)
+    dplyr::arrange(dplyr::desc(dplyr::if_any(dplyr::matches("name"),
+                                             ~ tolower(.) == tolower(match))))
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Multiple osm name matches are reordered so that exact matches are returned first. This fixes the city boundary issue observed in #159.

## Related Issues

- Related Issue #159 
- Closes #

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added entry in changelog?
_For user-facing changes, add a line describing the changes in [NEWS.md](/NEWS.md)_

- [x] Yes
