### PR TITLE
Error when river has no crossings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Exact matches in `match_osm_name()` are returned before partial matches.
 - Bug returning county boundary instead of city boundary was fixed.
+- Bug for river with no crossings was fixed. Delineation fails with informative error.
 
 # rcrisp 0.2.0 - 2025-08-21
 

--- a/R/corridor.R
+++ b/R/corridor.R
@@ -193,6 +193,9 @@ corridor_end_points <- function(river_network, spatial_network, regions) {
   inters_reg_2 <- find_intersections(network_2, river_network)
   # Identify common intersections between the two sub-networks
   intersections <- inters_reg_1[inters_reg_1 %in% inters_reg_2]
+  if (length(intersections) == 0) {
+    stop("No river crossings found. Corridor cannot be delineated.")
+  }
   # Make sure they are "POINTS" (no "MULTIPOINTS")
   intersections <- sfheaders::sfc_cast(intersections, "POINT")
 

--- a/tests/testthat/test-corridor.R
+++ b/tests/testthat/test-corridor.R
@@ -341,3 +341,19 @@ test_that("Errors are raised for wrong input types to corridor delineation", {
   expect_error(delineate_corridor(network_edges, river),
                "Assertion on 'network' failed")
 })
+
+test_that("When river has no crossing, delineation fails with informative
+          error.", {
+            river <- sf::st_sfc(sf::st_linestring(cbind(c(-3, 0.5), c(0, 0))),
+                                crs = 32635)
+            network_edges <- sf::st_sfc(
+              sf::st_linestring(cbind(c(1, -1), c(-1, -1))),
+              sf::st_linestring(cbind(c(1, -1), c(1, 1))),
+              sf::st_linestring(cbind(c(1, 1), c(1, -1))),
+              crs = 32635
+            )
+            spatial_network <- as_network(network_edges)
+
+            expect_error(delineate_corridor(spatial_network, river),
+                         "No river crossings found.")
+          })

--- a/tests/testthat/test-corridor.R
+++ b/tests/testthat/test-corridor.R
@@ -344,16 +344,23 @@ test_that("Errors are raised for wrong input types to corridor delineation", {
 
 test_that("When river has no crossing, delineation fails with informative
           error.", {
-            river <- sf::st_sfc(sf::st_linestring(cbind(c(-3, 0.5), c(0, 0))),
+            river <- sf::st_sfc(sf::st_linestring(cbind(c(-3, 0.1, 0.6),
+                                                        c(0, 0, 0))),
                                 crs = 32635)
             network_edges <- sf::st_sfc(
-              sf::st_linestring(cbind(c(1, -1), c(-1, -1))),
-              sf::st_linestring(cbind(c(1, -1), c(1, 1))),
-              sf::st_linestring(cbind(c(1, 1), c(1, -1))),
+              sf::st_linestring(matrix(c(3, -1,
+                                         -3, -1),
+                                       ncol = 2, byrow = TRUE)),
+              sf::st_linestring(matrix(c(3, 1,
+                                         -3, 1),
+                                       ncol = 2, byrow = TRUE)),
+              sf::st_linestring(matrix(c(1, 3,
+                                         1, -3),
+                                       ncol = 2, byrow = TRUE)),
               crs = 32635
             )
-            spatial_network <- as_network(network_edges)
+            network <- as_network(network_edges)
 
-            expect_error(delineate_corridor(spatial_network, river),
+            expect_error(delineate_corridor(network, river),
                          "No river crossings found.")
           })


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
If the network does not cross the river at all, delineation will fail with an informative error.

## Related Issues

- Related Issue #121
- Closes #121

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Added entry in changelog?

- [x] Yes
